### PR TITLE
Permission issue

### DIFF
--- a/rxbluetoothkotlin-core/src/main/AndroidManifest.xml
+++ b/rxbluetoothkotlin-core/src/main/AndroidManifest.xml
@@ -2,21 +2,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.masselis.rxbluetoothkotlin">
 
-    <uses-permission
-        android:name="android.permission.ACCESS_COARSE_LOCATION"
-        android:maxSdkVersion="28" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH"
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_ADMIN"
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
         android:maxSdkVersion="30" />
-    <uses-permission
-        android:name="android.permission.ACCESS_FINE_LOCATION"
-        android:maxSdkVersion="30" />
+    <!-- new Bluetooth permissions -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission
-        android:name="android.permission.BLUETOOTH_SCAN"
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
         android:usesPermissionFlags="neverForLocation"
         tools:ignore="UnusedAttribute" />
 


### PR DESCRIPTION
permission management prevented to ask location on app implementing the library on api > 30

It appears that Android that the stricter declaration and therefore prevent us from using the location permission on our app due to the 'maxSdkVersion' that was added in this lib.

Fell free to contact me for more infos on the tests that conducted me to this conclusion if needed